### PR TITLE
Fix insets

### DIFF
--- a/src/android/com/totalpave/cordova/insets/Insets.java
+++ b/src/android/com/totalpave/cordova/insets/Insets.java
@@ -43,7 +43,8 @@ public class Insets extends CordovaPlugin {
                     float density = this.cordova.getActivity().getResources().getDisplayMetrics().density;
 
                     // Ideally, we'd import this, but it shares the same name as our plugin
-                    androidx.core.graphics.Insets insets = insetProvider.getInsets(WindowInsetsCompat.Type.systemBars());
+                    int insetTypes = WindowInsetsCompat.Type.displayCutout() | WindowInsetsCompat.Type.systemBars();
+                    androidx.core.graphics.Insets insets = insetProvider.getInsets(insetTypes);
                     
                     result.put("top", insets.top / density);
                     result.put("right", insets.right / density);


### PR DESCRIPTION
When using this plugin I noticed that when I rotate to landscape the left and right area of the app always get a zero sized inset. 

With this change I get the correct inset for all of the sides of the display.