### PR TITLE
fix(breaking): account for rounded corners

### DIFF
--- a/src/android/com/totalpave/cordova/insets/Insets.java
+++ b/src/android/com/totalpave/cordova/insets/Insets.java
@@ -87,9 +87,8 @@ public class Insets extends CordovaPlugin {
                     double bottom = insets.bottom / density;
                     double left = insets.left / density;
 
-                    // These insets, if present may (and likely) exceed the rounded corner radius
-                    // Therefore, we will take the maximum value out of the two. If the inset is
-                    // greater, it will be used, otherwise the corner radius will be used as the inset.
+                    // Insets do not include rounded corner radius. If an inset is present, it generally will be big enough to cover the rounded corner. This is a coincidence, not a designed thing.
+                    // In either case, we need to determine how much space is required to cover the rounded corner and take the higher betwen the inset and the rounded corner.
 
                     top = Math.max(Math.max(top, topLeftRadius), topRightRadius);
                     bottom = Math.max(Math.max(bottom, botLeftRadius), botRightRadius);


### PR DESCRIPTION

This change is only for API 31+ devices.

This change is API guarded for API 31+, there is no `WindowInsetsCompat` API into rounded corners API. For older API devices, rounded corners will simply resolve to `0.0`.

#### BREAKING CHANGE NOTICE

While the plugin itself doesn't introduce a breaking change in the public API, cordova-android@11 is required (or at least compile SDK needs to be set to 31 or later).

Because existing display cutout / system bar insets already covers any rounded corners, we will take the maximum value between the rounded corner values and the current found inset.

Insets operates on sides, not corners. So when resolving top for example, we look at both top left, and top right corners. Left side is resolved by looking top left, bottom left, so on.

