### PR TITLE
Added ime inset type for keyboard open

### DIFF
--- a/src/android/com/totalpave/cordova/insets/Insets.java
+++ b/src/android/com/totalpave/cordova/insets/Insets.java
@@ -44,7 +44,7 @@ public class Insets extends CordovaPlugin {
                     float density = this.cordova.getActivity().getResources().getDisplayMetrics().density;
 
                     // Ideally, we'd import this, but it shares the same name as our plugin
-                    int insetTypes = WindowInsetsCompat.Type.displayCutout() | WindowInsetsCompat.Type.systemBars();
+                    int insetTypes = WindowInsetsCompat.Type.displayCutout() | WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.ime();
                     androidx.core.graphics.Insets insets = insetProvider.getInsets(insetTypes);
 
                     double topLeftRadius = 0.0;


### PR DESCRIPTION
Adding ime inset type lets us get the inset for when the keyboard is open, otherwise the keyboard will overlay the bottom part of any form and hide any input field.