### PR TITLE
feat(android): add enableEdgeToEdge mode with default safe-margin backward compatibility

### DIFF
--- a/src/android/com/totalpave/cordova/inset/Inset.java
+++ b/src/android/com/totalpave/cordova/inset/Inset.java
@@ -20,6 +20,8 @@ import android.content.res.Configuration;
 import android.content.Context;
 import android.os.Build;
 import android.view.RoundedCorner;
+import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowInsets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -247,12 +249,13 @@ public class Inset extends CordovaPlugin {
     private ArrayList<Listener> $listeners;
     private HashMap<String, Listener> $listenerMap;
     private final Object $listenerLock = new Object();
+    private volatile boolean $edgeToEdgeEnabled = false;
 
     @Override
     protected void pluginInitialize() {
         $listeners = new ArrayList<>();
         $listenerMap = new HashMap<>();
-        
+
         ViewCompat.setOnApplyWindowInsetsListener(
                 this.cordova.getActivity().findViewById(android.R.id.content), (v, insetProvider) -> {
 
@@ -262,9 +265,68 @@ public class Inset extends CordovaPlugin {
                         }
                     }
 
-                    return WindowInsetsCompat.CONSUMED;
+                    return insetProvider;
                 }
         );
+
+        // WebView-level listener that fires after CordovaActivity's rootLayout listener.
+        // Default mode: applies system bar margins for backward compatibility.
+        // Edge-to-edge mode: only applies IME margin for keyboard resize.
+        View wv = this.webView.getView();
+        if (wv != null) {
+            ViewCompat.setOnApplyWindowInsetsListener(wv, (view, insets) -> {
+                androidx.core.graphics.Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
+                ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+                if (params == null) {
+                    return insets;
+                }
+
+                if ($edgeToEdgeEnabled) {
+                    int newBottom = imeInsets.bottom;
+                    if (newBottom != params.bottomMargin) {
+                        params.bottomMargin = newBottom;
+                        view.setLayoutParams(params);
+                    }
+                } else {
+                    androidx.core.graphics.Insets barInsets = insets.getInsets(
+                        WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
+                    );
+                    int newTop = barInsets.top;
+                    int newBottom = Math.max(barInsets.bottom, imeInsets.bottom);
+                    int newLeft = barInsets.left;
+                    int newRight = barInsets.right;
+                    if (params.topMargin != newTop || params.bottomMargin != newBottom
+                            || params.leftMargin != newLeft || params.rightMargin != newRight) {
+                        params.topMargin = newTop;
+                        params.bottomMargin = newBottom;
+                        params.leftMargin = newLeft;
+                        params.rightMargin = newRight;
+                        view.setLayoutParams(params);
+                    }
+                }
+                return insets;
+            });
+        }
+    }
+
+    private void $enableEdgeToEdge(CallbackContext callback) {
+        $edgeToEdgeEnabled = true;
+        cordova.getActivity().runOnUiThread(() -> {
+            View wv = this.webView.getView();
+            if (wv != null) {
+                ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) wv.getLayoutParams();
+                if (params != null) {
+                    params.topMargin = 0;
+                    params.bottomMargin = 0;
+                    params.leftMargin = 0;
+                    params.rightMargin = 0;
+                    wv.setLayoutParams(params);
+                }
+                // Re-request insets so the IME-only listener path takes effect.
+                ViewCompat.requestApplyInsets(wv);
+            }
+        });
+        callback.success();
     }
 
     private void $createNewListener(CallbackContext callback, JSONArray args) {
@@ -329,6 +391,10 @@ public class Inset extends CordovaPlugin {
         }
         else if (action.equals("delete")) {
             $freeListener(callback, args);
+            return true;
+        }
+        else if (action.equals("enableEdgeToEdge")) {
+            $enableEdgeToEdge(callback);
             return true;
         }
 

--- a/src/www/Inset.ts
+++ b/src/www/Inset.ts
@@ -201,6 +201,28 @@ export class Inset {
     private static $isUpdateEvent(e: IInsetEvent): e is IInsetUpdateEvent {
         return e.type === 'update';
     }
+   
+   /**
+   * Opts into edge-to-edge mode, removing the plugin's default
+   * safety margins on the WebView. Call before creating listeners
+   * when the app handles insets via CSS.
+   *
+   * For backward compatibility, the plugin applies system bar margins
+   * by default so apps that don't call this method remain safe.
+   */
+   public static enableEdgeToEdge(): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            cordova.exec(
+                () => {
+                    resolve();
+                },
+                reject,
+                SERVICE_NAME,
+                "enableEdgeToEdge",
+                []
+            );
+        });
+    }
 }
 
 declare global {


### PR DESCRIPTION
Starting with Android 15 (SDK 35), apps that target SDK 35+ are enforced into edge-to-edge mode, the system no longer applies default inset padding to the WebView. This means web content renders behind the status bar, navigation bar, and display cutout unless the app explicitly handles insets.

The previous plugin implementation returned [WindowInsetsCompat.CONSUMED] from the content-level inset listener, which blocked insets from propagating to CordovaActivity's rootLayout listener. This caused two critical issues:

1. WebView content drawn behind system bars, no native margins were applied, so unless the JS code already compensated with CSS, the UI was clipped.
2. Keyboard (IME) resize broken, CordovaActivity normally adjusts the WebView's bottom margin when the soft keyboard opens. Since CONSUMED stopped inset propagation entirely, the WebView never shrank and the keyboard covered input fields.

See: [Make Webviews edge-to-edge](https://medium.com/androiddevelopers/make-webviews-edge-to-edge-a6ef319adfac)

**Why backward compatibility matters**
Many Cordova apps use hot-code-push (HCP) or similar mechanisms that replace JS/CSS bundles from a server at runtime while the native plugin stays at the installed version. This creates a version mismatch scenarioes

**Solution**
**1. Stop consuming insets, pass them through ([return insetProvider]**
The content-level OnApplyWindowInsetsListener now returns [insetProvider](vscode-file://vscode-app/c:/vscode/Planon-VSCode-win32-x64-1.114.0_v0.1/vscode/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of [WindowInsetsCompat.CONSUMED](vscode-file://vscode-app/c:/vscode/Planon-VSCode-win32-x64-1.114.0_v0.1/vscode/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html), allowing insets to propagate down the view hierarchy so CordovaActivity's existing rootLayout listener (and the new WebView listener) can both receive them.

**2. WebView-level inset listener with dual-mode behavior**
A new OnApplyWindowInsetsListener is attached directly to the WebView in [pluginInitialize()]. It operates in two modes controlled by a [volatile boolean $edgeToEdgeEnabled] flag:

Default mode ([$edgeToEdgeEnabled = false]: Applies [systemBars | displayCutout] margins to the WebView, plus [IME] bottom margin, acting as a safety net. This ensures that if old JS code is loaded (via HCP or otherwise), the WebView content stays within safe bounds and the keyboard still resizes the view.

Edge-to-edge mode ([$edgeToEdgeEnabled = true]: Only applies [IME] bottom margin for keyboard resize. All other inset handling is deferred to the JS/CSS layer, which has full control via the plugin's inset listener callbacks + CSS custom properties.

**3. [enableEdgeToEdge] action & JS API**
A new Cordova action ["enableEdgeToEdge"] is exposed

**4. IME keyboard handling**
The WebView listener always reads [WindowInsetsCompat.Type.ime()] regardless of mode. When the soft keyboard opens, the WebView's bottom margin is set to the IME inset height, shrinking the WebView above the keyboard. When it closes, the margin returns to 0 (edge-to-edge mode) or the system bar value (default mode). This fixes the keyboard resize that was broken by the old CONSUMED return.

With this:
- Apps that don't call [enableEdgeToEdge()] get automatic system bar margins, identical safe behavior to pre-edge-to-edge Android.
- Apps that do call it opt into full control, with only keyboard resize handled natively.
- The [enableEdgeToEdge] action is additive, old plugin versions that don't recognize it will trigger [cordova.exec]'s error callback, which callers can safely ignore.